### PR TITLE
Transform list contents in annotation defaults, in addition to arrays

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlin/abicmp/AnnotationsProperty.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/abicmp/AnnotationsProperty.kt
@@ -25,7 +25,8 @@ fun Any?.toAnnotation(): AnnotationEntry? {
 
 fun Any.toAnnotationArgumentValue(): Any =
         when (this) {
-            is Array<*> -> toList().map { it!!.toAnnotationArgumentValue() }
+            is Array<*> -> map { it!!.toAnnotationArgumentValue() }
+            is List<*> -> map { it!!.toAnnotationArgumentValue() }
             is AnnotationNode -> this.toAnnotation()!!
             else -> this
         }


### PR DESCRIPTION
This fixes incorrect differences in arrays of enums (which are
represented as List<Array<String>> in ASM), such as in
`ScriptExpectedLocations` in the Kotlin project.